### PR TITLE
Fix blueprint validations and encoding

### DIFF
--- a/pws_weather_upload.yaml
+++ b/pws_weather_upload.yaml
@@ -142,7 +142,7 @@ variables:
   enable_logging: !input enable_logging
 
   baromin: >
-    {% if baromin_entity != '' and states(baromin_entity) is not none %}
+    {% if baromin_entity != '' and states(baromin_entity) is not none and states(baromin_entity) not in ['unknown', 'unavailable'] %}
       {% set unit = state_attr(baromin_entity, 'unit_of_measurement') %}
       {% if unit == 'hPa' %}
         {{ (states(baromin_entity) | float) / 33.8639 }}
@@ -154,7 +154,7 @@ variables:
     {% endif %}
 
   tempf: >
-    {% if tempf_entity != '' and states(tempf_entity) is not none %}
+    {% if tempf_entity != '' and states(tempf_entity) is not none and states(tempf_entity) not in ['unknown', 'unavailable'] %}
       {% set unit = state_attr(tempf_entity, 'unit_of_measurement') %}
       {% if unit == '°C' %}
         {{ (states(tempf_entity) | float) * 1.8 + 32 }}
@@ -166,21 +166,21 @@ variables:
     {% endif %}
 
   humidity: >
-    {% if humidity_entity != '' and states(humidity_entity) is not none %}
+    {% if humidity_entity != '' and states(humidity_entity) is not none and states(humidity_entity) not in ['unknown', 'unavailable'] %}
       {{ states(humidity_entity) | float }}
     {% else %}
       none
     {% endif %}
 
   winddir: >
-    {% if winddir_entity != '' and states(winddir_entity) is not none %}
+    {% if winddir_entity != '' and states(winddir_entity) is not none and states(winddir_entity) not in ['unknown', 'unavailable'] %}
       {{ states(winddir_entity) | float }}
     {% else %}
       none
     {% endif %}
 
   windspeedmph: >
-    {% if windspeedmph_entity != '' and states(windspeedmph_entity) is not none %}
+    {% if windspeedmph_entity != '' and states(windspeedmph_entity) is not none and states(windspeedmph_entity) not in ['unknown', 'unavailable'] %}
       {% set unit = state_attr(windspeedmph_entity, 'unit_of_measurement') %}
       {% if unit == 'km/h' %}
         {{ (states(windspeedmph_entity) | float) * 0.621371 }}
@@ -192,7 +192,7 @@ variables:
     {% endif %}
 
   windgustmph: >
-    {% if windgustmph_entity != '' and states(windgustmph_entity) is not none %}
+    {% if windgustmph_entity != '' and states(windgustmph_entity) is not none and states(windgustmph_entity) not in ['unknown', 'unavailable'] %}
       {% set unit = state_attr(windgustmph_entity, 'unit_of_measurement') %}
       {% if unit == 'km/h' %}
         {{ (states(windgustmph_entity) | float) * 0.621371 }}
@@ -204,7 +204,7 @@ variables:
     {% endif %}
 
   rainin: >
-    {% if rainin_entity != '' and states(rainin_entity) is not none %}
+    {% if rainin_entity != '' and states(rainin_entity) is not none and states(rainin_entity) not in ['unknown', 'unavailable'] %}
       {% set unit = state_attr(rainin_entity, 'unit_of_measurement') %}
       {% if unit == 'mm' %}
         {{ (states(rainin_entity) | float) * 0.0393701 }}
@@ -216,7 +216,7 @@ variables:
     {% endif %}
 
   dailyrainin: >
-    {% if dailyrainin_entity != '' and states(dailyrainin_entity) is not none %}
+    {% if dailyrainin_entity != '' and states(dailyrainin_entity) is not none and states(dailyrainin_entity) not in ['unknown', 'unavailable'] %}
       {% set unit = state_attr(dailyrainin_entity, 'unit_of_measurement') %}
       {% if unit == 'mm' %}
         {{ (states(dailyrainin_entity) | float) * 0.0393701 }}
@@ -228,21 +228,21 @@ variables:
     {% endif %}
 
   solarradiation: >
-    {% if solarradiation_entity != '' and states(solarradiation_entity) is not none %}
+    {% if solarradiation_entity != '' and states(solarradiation_entity) is not none and states(solarradiation_entity) not in ['unknown', 'unavailable'] %}
       {{ states(solarradiation_entity) | float }}
     {% else %}
       none
     {% endif %}
 
   UV: >
-    {% if UV_entity != '' and states(UV_entity) is not none %}
+    {% if UV_entity != '' and states(UV_entity) is not none and states(UV_entity) not in ['unknown', 'unavailable'] %}
       {{ states(UV_entity) | int }}
     {% else %}
       none
     {% endif %}
 
   dewptf: >
-    {% if calculate_dewpt and tempf != 'none' and humidity != 'none' %}
+    {% if calculate_dewpt and tempf != 'none' and humidity != 'none' and (humidity | float) > 0 %}
       {% set T = tempf | float %}
       {% set RH = humidity | float %}
       {# Convert F to C for dew point calculation #}
@@ -263,7 +263,7 @@ variables:
     {% for i in [
           ['ID', station_id],
           ['PASSWORD', station_key],
-          ['dateutc', (now().utcnow().strftime('%Y-%m-%d %H:%M:%S') | replace(' ', '+'))],
+          ['dateutc', (utcnow().strftime('%Y-%m-%d %H:%M:%S') | replace(' ', '+'))],
           ['tempf', tempf],
           ['humidity', humidity],
           ['winddir', winddir],
@@ -279,7 +279,7 @@ variables:
           ['action', 'updateraw']
         ] %}
       {% if i[1] != 'none' and i[1] != '' %}
-        {% set data.sensors = data.sensors + ['{}={}'.format(i[0], i[1])] %}
+        {% set data.sensors = data.sensors + ['{}={}'.format(i[0] | urlencode, i[1] | urlencode)] %}
       {% endif %}
     {% endfor %}
     {{ data.sensors | join('&') }}


### PR DESCRIPTION
## Summary
- sanitize sensor states before processing
- guard dew point calculation when humidity is zero
- generate UTC timestamp correctly
- urlencode query parameters

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: disable, document-start: disable}}' pws_weather_upload.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6846b039689883269a7c36a2d272de2a