### PR TITLE
Use rest_command and throttle uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 Upload weather data from Home Assistant to a PWS Weather station
 
 ## Setup
-1. Add the following lines to your Home Assistant configuration.yaml. This
-   defines a `shell_command` named `curl_post` that will be used by the
-   blueprint to perform the HTTP request to PWSWeather. Your Station ID and
+1. Add the following lines to your Home Assistant `configuration.yaml`. This
+   defines a `rest_command` named `pws_upload` that the blueprint uses to send
+   data to PWSWeather without spawning an external process. Your Station ID and
    API key will be passed as part of the request URL:
 ```
-shell_command:
-  curl_post: "curl -X POST \"{{ url }}\""
+rest_command:
+  pws_upload:
+    url: "{{ url }}"
+    method: POST
 ```
 
 2. Restart Home Assistant.
@@ -20,7 +22,15 @@ shell_command:
 
 5. Enter your Station ID and API Key, then any weather values to share.
 6. Ensure you select an entity to trigger data uploads (e.g. a temperature sensor).
-7. Save Automation.
+7. Optionally set a **Minimum Upload Interval** if you want to throttle how
+   often data is sent to PWSWeather.
+8. Choose any extra sensors you wish to include such as **Monthly** or
+   **Yearly Rainfall** and set a **Weather Condition** string if desired.
+9. Override the **Software Type** if you want a custom value.
+10. Save Automation.
+
+When logging is enabled, the blueprint records the HTTP status code returned
+by the PWSWeather API so you can confirm successful uploads.
 
 The file `PWSweather-API_string_2020.txt` lists all parameters supported by the
 PWSWeather API. Use it as a reference when deciding which sensors to include.

--- a/pws_weather_upload.yaml
+++ b/pws_weather_upload.yaml
@@ -6,8 +6,10 @@ blueprint:
     supported by PWSWeather.
 
     As a pre-requisite, add the following to your configuration.yaml:
-    shell_command:
-      curl_post: "curl -X POST \"{{ url }}\""
+    rest_command:
+      pws_upload:
+        url: "{{ url }}"
+        method: POST
 
   domain: automation
   input:
@@ -78,6 +80,31 @@ blueprint:
           domain: sensor
           device_class: precipitation
       default: ''
+    monthrainin_entity:
+      name: Monthly Rainfall (in millimeters or inches)
+      selector:
+        entity:
+          domain: sensor
+          device_class: precipitation
+      default: ''
+    yearrainin_entity:
+      name: Yearly Rainfall (in millimeters or inches)
+      selector:
+        entity:
+          domain: sensor
+          device_class: precipitation
+      default: ''
+    weather_condition:
+      name: Weather Condition (e.g. -RA, +SN, SKC)
+      selector:
+        text: {}
+      default: ''
+    softwaretype:
+      name: Software Type
+      description: Sent as the `softwaretype` parameter.
+      selector:
+        text: {}
+      default: HomeAssistant
     solarradiation_entity:
       name: Solar Radiation Sensor (in W/m2)
       selector:
@@ -105,11 +132,23 @@ blueprint:
           filter:
             domain: sensor
       default: ''
-    curl_command_service:
-      name: CURL Command Service
+    rest_command_service:
+      name: REST Command Service
       selector:
         text: {}
-      default: shell_command.curl_post
+      default: rest_command.pws_upload
+    min_upload_interval:
+      name: Minimum Upload Interval (minutes)
+      description: >
+        Minimum number of minutes between uploads. Set to 0 to disable
+        throttling.
+      selector:
+        number:
+          min: 0
+          max: 60
+          mode: box
+          unit_of_measurement: minutes
+      default: 0
     enable_logging:
       name: Enable Logging
       description: Log upload attempts to `system_log`. The API key is never
@@ -136,10 +175,15 @@ variables:
   windgustmph_entity: !input windgustmph_entity
   rainin_entity: !input rainin_entity
   dailyrainin_entity: !input dailyrainin_entity
+  monthrainin_entity: !input monthrainin_entity
+  yearrainin_entity: !input yearrainin_entity
   solarradiation_entity: !input solarradiation_entity
   UV_entity: !input UV_entity
+  weather_condition: !input weather_condition
+  softwaretype: !input softwaretype
   calculate_dewpt: !input calculate_dewpt
   enable_logging: !input enable_logging
+  min_upload_interval: !input min_upload_interval
 
   baromin: >
     {% if baromin_entity != '' and states(baromin_entity) is not none and states(baromin_entity) not in ['unknown', 'unavailable'] %}
@@ -227,6 +271,30 @@ variables:
       none
     {% endif %}
 
+  monthrainin: >
+    {% if monthrainin_entity != '' and states(monthrainin_entity) is not none and states(monthrainin_entity) not in ['unknown', 'unavailable'] %}
+      {% set unit = state_attr(monthrainin_entity, 'unit_of_measurement') %}
+      {% if unit == 'mm' %}
+        {{ (states(monthrainin_entity) | float) * 0.0393701 }}
+      {% else %}
+        {{ states(monthrainin_entity) | float }}
+      {% endif %}
+    {% else %}
+      none
+    {% endif %}
+
+  yearrainin: >
+    {% if yearrainin_entity != '' and states(yearrainin_entity) is not none and states(yearrainin_entity) not in ['unknown', 'unavailable'] %}
+      {% set unit = state_attr(yearrainin_entity, 'unit_of_measurement') %}
+      {% if unit == 'mm' %}
+        {{ (states(yearrainin_entity) | float) * 0.0393701 }}
+      {% else %}
+        {{ states(yearrainin_entity) | float }}
+      {% endif %}
+    {% else %}
+      none
+    {% endif %}
+
   solarradiation: >
     {% if solarradiation_entity != '' and states(solarradiation_entity) is not none and states(solarradiation_entity) not in ['unknown', 'unavailable'] %}
       {{ states(solarradiation_entity) | float }}
@@ -237,6 +305,13 @@ variables:
   UV: >
     {% if UV_entity != '' and states(UV_entity) is not none and states(UV_entity) not in ['unknown', 'unavailable'] %}
       {{ states(UV_entity) | int }}
+    {% else %}
+      none
+    {% endif %}
+
+  weather: >
+    {% if weather_condition != '' %}
+      {{ weather_condition }}
     {% else %}
       none
     {% endif %}
@@ -273,9 +348,12 @@ variables:
           ['dewptf', dewptf],
           ['rainin', rainin],
           ['dailyrainin', dailyrainin],
+          ['monthrainin', monthrainin],
+          ['yearrainin', yearrainin],
           ['solarradiation', solarradiation],
           ['UV', UV],
-          ['softwaretype', 'HomeAssistant'],
+          ['weather', weather],
+          ['softwaretype', softwaretype],
           ['action', 'updateraw']
         ] %}
       {% if i[1] != 'none' and i[1] != '' %}
@@ -284,12 +362,27 @@ variables:
     {% endfor %}
     {{ data.sensors | join('&') }}
 
+condition:
+  - condition: template
+    value_template: >
+      {% if min_upload_interval | int == 0 %}
+        true
+      {% else %}
+        {% set last = state_attr(this.entity_id, 'last_triggered') %}
+        {% if last %}
+          {{ (as_timestamp(now()) - as_timestamp(last)) > (min_upload_interval | int * 60) }}
+        {% else %}
+          true
+        {% endif %}
+      {% endif %}
+
 action:
-  - alias: "Check if station_id and station_key exist"
+  - alias: "Check credentials and send data"
     if: >
       {{ station_id != '' and station_key != '' }}
     then:
-      - service: !input curl_command_service
+      - service: !input rest_command_service
+        response_variable: resp
         data:
           url: "https://pwsupdate.pwsweather.com/api/v1/submitwx?{{ payload }}"
       - if: "{{ enable_logging }}"
@@ -297,7 +390,9 @@ action:
           - service: system_log.write
             data:
               level: info
-              message: "HTTP request sent to PWSWeather API. Station ID: {{ station_id }}."
+              message: >
+                Upload response {{ resp.status | default('unknown') }} from
+                PWSWeather API for Station ID {{ station_id }}.
     else:
       - service: system_log.write
         data:


### PR DESCRIPTION
## Summary
- use `rest_command` instead of shelling out to curl
- document new setup instructions in README
- add option to throttle uploads
- update automation to respect throttle and call the REST command
- allow extra API fields and software type
- log HTTP response status

## Testing
- `pip install pyyaml >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python - <<'PY'
import yaml
class Loader(yaml.SafeLoader):
    pass
Loader.add_constructor('!input', lambda loader,node: node.value)
Loader.add_constructor('!placeholder', lambda l,n: n.value)
print('YAML OK') if yaml.load(open('pws_weather_upload.yaml'), Loader) else None
PY`

------
https://chatgpt.com/codex/tasks/task_e_684d5fd432748326bc052e56880e80b6