### PR TITLE
Add Home Assistant blueprint validation workflow

### DIFF
--- a/.github/workflows/validate-home-assistant-blueprints.yml
+++ b/.github/workflows/validate-home-assistant-blueprints.yml
@@ -1,0 +1,72 @@
+name: Validate Home Assistant blueprints
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "pws_weather_upload.yaml"
+      - "blueprints/**/*.ya?ml"
+  push:
+    branches:
+      - main
+    paths:
+      - "pws_weather_upload.yaml"
+      - "blueprints/**/*.ya?ml"
+
+jobs:
+  blueprint-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Home Assistant Core
+        run: |
+          python --version
+          pip install --upgrade pip
+          pip install "homeassistant==2025.6.0"
+          python - <<'PY'
+          from importlib.metadata import version
+          import sys
+          print("HA OK", version("homeassistant"), sys.version)
+          PY
+
+      - name: Determine files to validate
+        id: files
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            CHANGED=$(
+              git diff --name-only "${{ github.event.pull_request.base.sha }}" \
+                                  "${{ github.sha }}" |
+              grep -E '^(pws_weather_upload\.yaml|blueprints/.*\.ya?ml)$' || true
+            )
+            {
+              echo "files<<EOF"
+              echo "${CHANGED}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            FILES=$(
+              find . -type f \( -name '*.yaml' -o -name '*.yml' \) \
+                \( -name 'pws_weather_upload.yaml' -o -path './blueprints/*' \) |
+              sed 's#^\./##' |
+              sort
+            )
+            {
+              echo "files<<EOF"
+              echo "${FILES}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate blueprints
+        env:
+          FILES: ${{ steps.files.outputs.files }}
+        run: |
+          python scripts/ha_blueprint_validate.py ${FILES:-pws_weather_upload.yaml blueprints/**/*.yaml blueprints/**/*.yml}

--- a/scripts/ha_blueprint_validate.py
+++ b/scripts/ha_blueprint_validate.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Validate Home Assistant blueprint YAML files."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+from importlib.metadata import version as package_version
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util.yaml import YamlTypeError, extract_inputs
+from homeassistant.util.yaml.loader import load_yaml_dict
+
+DEFAULT_PATTERNS = (
+    "pws_weather_upload.yaml",
+    "blueprints/**/*.yaml",
+    "blueprints/**/*.yml",
+)
+GLOB_CHARS = set("*?[")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _has_glob(pattern: str) -> bool:
+    return any(char in pattern for char in GLOB_CHARS)
+
+
+def expand_patterns(patterns: list[str]) -> list[Path]:
+    """Expand a mix of explicit file paths and glob patterns."""
+    matched: dict[Path, None] = {}
+
+    for pattern in patterns or list(DEFAULT_PATTERNS):
+        if _has_glob(pattern):
+            for match in sorted(glob.glob(pattern, recursive=True)):
+                path = Path(match)
+                if path.is_file():
+                    matched[path] = None
+            continue
+
+        path = Path(pattern)
+        if path.is_file():
+            matched[path] = None
+
+    return list(matched)
+
+
+def _require_mapping(value: object, label: str) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    return value
+
+
+def _optional_string(value: object, label: str) -> None:
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+
+
+def _parse_version(version: str) -> tuple[int, int, int]:
+    if not VERSION_RE.match(version):
+        raise ValueError(
+            "blueprint.homeassistant.min_version must be formatted as "
+            "{major}.{minor}.{patch}"
+        )
+    return tuple(int(part) for part in version.split("."))
+
+
+def _validate_url(value: str, label: str) -> None:
+    parsed = urlparse(value)
+    if not parsed.scheme or not parsed.netloc:
+        raise ValueError(f"{label} must be a valid URL")
+
+
+def _validate_input_definition(value: object, label: str) -> None:
+    if value is None:
+        return
+
+    mapping = _require_mapping(value, label)
+    for key in ("name", "description"):
+        _optional_string(mapping.get(key), f"{label}.{key}")
+
+    selector = mapping.get("selector")
+    if selector is not None and not isinstance(selector, dict):
+        raise ValueError(f"{label}.selector must be a mapping")
+
+
+def _validate_input_section(value: object, label: str) -> dict[str, object]:
+    mapping = _require_mapping(value, label)
+    for key in ("name", "icon", "description"):
+        _optional_string(mapping.get(key), f"{label}.{key}")
+
+    collapsed = mapping.get("collapsed")
+    if collapsed is not None and not isinstance(collapsed, bool):
+        raise ValueError(f"{label}.collapsed must be a boolean")
+
+    inputs = _require_mapping(mapping.get("input"), f"{label}.input")
+    for key, input_value in inputs.items():
+        _validate_input_definition(input_value, f"{label}.input.{key}")
+    return inputs
+
+
+def _flatten_blueprint_inputs(inputs: dict[str, object]) -> set[str]:
+    flat_inputs: set[str] = set()
+
+    for key, value in inputs.items():
+        if isinstance(value, dict) and "input" in value:
+            section_inputs = _validate_input_section(value, f"blueprint.input.{key}")
+            duplicates = flat_inputs.intersection(section_inputs)
+            if duplicates:
+                dupes = ", ".join(sorted(duplicates))
+                raise ValueError(f"Duplicate use of input key(s): {dupes}")
+            flat_inputs.update(section_inputs)
+            continue
+
+        _validate_input_definition(value, f"blueprint.input.{key}")
+        if key in flat_inputs:
+            raise ValueError(f"Duplicate use of input key: {key}")
+        flat_inputs.add(key)
+
+    return flat_inputs
+
+
+def validate_blueprint(path: Path) -> tuple[str, str]:
+    """Load and validate a Home Assistant blueprint file."""
+    data = _require_mapping(load_yaml_dict(path), "file")
+    blueprint = _require_mapping(data.get("blueprint"), "blueprint")
+    name = _require_string(blueprint.get("name"), "blueprint.name")
+    domain = _require_string(blueprint.get("domain"), "blueprint.domain")
+    _optional_string(blueprint.get("description"), "blueprint.description")
+    _optional_string(blueprint.get("author"), "blueprint.author")
+
+    source_url = blueprint.get("source_url")
+    if source_url is not None:
+        _validate_url(
+            _require_string(source_url, "blueprint.source_url"),
+            "blueprint.source_url",
+        )
+
+    ha_metadata = blueprint.get("homeassistant")
+    if ha_metadata is not None:
+        metadata = _require_mapping(ha_metadata, "blueprint.homeassistant")
+        min_version_value = metadata.get("min_version")
+        if min_version_value is not None:
+            min_version = _parse_version(
+                _require_string(min_version_value, "blueprint.homeassistant.min_version")
+            )
+            current_version = _parse_version(package_version("homeassistant"))
+            if current_version < min_version:
+                raise HomeAssistantError(
+                    f"Requires at least Home Assistant {min_version_value}"
+                )
+
+    inputs = blueprint.get("input", {})
+    input_mapping = _require_mapping(inputs, "blueprint.input")
+    defined_inputs = _flatten_blueprint_inputs(input_mapping)
+    referenced_inputs = set(extract_inputs(data))
+    missing_inputs = referenced_inputs - defined_inputs
+    if missing_inputs:
+        missing = ", ".join(sorted(missing_inputs))
+        raise ValueError(f"Missing input definition for {missing}")
+
+    return name, domain
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Home Assistant blueprint YAML files."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Blueprint files or glob patterns to validate.",
+    )
+    args = parser.parse_args()
+
+    files = expand_patterns(args.files)
+    if not files:
+        print("No blueprint files found to validate.")
+        return 0
+
+    failures = 0
+    for path in files:
+        try:
+            name, domain = validate_blueprint(path)
+        except (HomeAssistantError, YamlTypeError, FileNotFoundError, ValueError) as err:
+            failures += 1
+            print(f"FAIL {path}: {err}", file=sys.stderr)
+            continue
+
+        print(f"OK   {path}: {name} ({domain})")
+
+    if failures:
+        print(f"{failures} blueprint file(s) failed validation.", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(files)} blueprint file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to validate Home Assistant blueprint YAML changes and add a small validator script that uses Home Assistant's YAML loader plus blueprint-specific structural checks. This makes blueprint regressions visible in CI before merge.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

CI workflow and validation tooling.

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
/tmp/pwsweatherupload-ha-test-313/bin/python scripts/ha_blueprint_validate.py pws_weather_upload.yaml
```

Add any extra commands, targeted tests, or manual validation below.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The workflow was adapted to this repository's current layout by validating the root blueprint file `pws_weather_upload.yaml` in addition to any future files under `blueprints/`.